### PR TITLE
rhash 1.4.6 

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,8 +3,6 @@ set -x
 
 if [[ ${target_platform} =~ .*linux*. ]]; then
   RPATH="-Wl,-rpath-link,${PREFIX}/lib"
-elif [[ ${target_platform} == osx-64 ]]; then
-  RPATH="-Wl,-rpath,${PREFIX}/lib"
 fi
 
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib ${RPATH}"
@@ -12,7 +10,6 @@ export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib ${RPATH}"
 ./configure \
   --enable-openssl \
   --prefix=$PREFIX \
-  --enable-lib-static \
   --enable-lib-shared \
   --extra-cflags="$CFLAGS -I$PREFIX/include" \
   --extra-ldflags="$LDFLAGS" \
@@ -22,5 +19,5 @@ make install install-lib-headers install-lib-so-link
 make check
 
 if [[ ${HOST} =~ .*darwin.* ]]; then
-  ${INSTALL_NAME_TOOL:-install_name_tool} -id @rpath/librhash.0.dylib ${PREFIX}/lib/librhash.0.dylib
+  ${INSTALL_NAME_TOOL:-install_name_tool} -id @rpath/librhash.1.dylib ${PREFIX}/lib/librhash.1.dylib
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,13 @@
 {% set name = "rhash" %}
-{% set version = "1.4.3" %}
+{% set version = "1.4.6" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://github.com/rhash/RHash/archive/v{{ version }}.tar.gz
-  sha256: 1e40fa66966306920f043866cbe8612f4b939b033ba5e2708c3f41be257c8a3e
+  url: https://github.com/{{ name }}/RHash/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 9f6019cfeeae8ace7067ad22da4e4f857bb2cfa6c2deaa2258f55b2227ec937a
 
 build:
   number: 0
@@ -31,23 +30,26 @@ requirements:
 test:
   source_files:
     - tests
-
   commands:
     - test -f "$PREFIX/include/rhash.h"
     - test -f "$PREFIX/lib/librhash${SHLIB_EXT}"  # [unix]
-    - test -f "$PREFIX/lib/librhash.so.0"  # [linux]
-    - test -f "$PREFIX/lib/librhash.0.dylib"  # [osx]
+    - test -f "$PREFIX/lib/librhash.so.1"  # [linux]
+    - test -f "$PREFIX/lib/librhash.1.dylib"  # [osx]
     - rhash --version
-    - tests/test_rhash.sh  # [unix]
+    # The rhash variable was already set in the conda-build environment with the value "1",
+    # which prevented the test script from overwriting it with the actual binary path from the command-line argument.
+    - unset rhash OPT_SHARED OPT_FULL
+    - ./tests/test_rhash.sh --shared $PREFIX/bin/rhash
 
 about:
-  home: https://rhash.sourceforge.net/
+  home: https://rhash.sourceforge.net
   license: MIT
   license_family: MIT
   license_file: COPYING
   summary: Great utility for computing hash sums
   description: |
-    RHash is a console utility for computing and verifying hash sums of files. It supports CRC32, MD4, MD5, SHA1, SHA256, SHA512, SHA3, Tiger, TTH, Torrent BTIH, AICH, ED2K, GOST R 34.11-94, RIPEMD-160, HAS-160, EDON-R 256/512, WHIRLPOOL and SNEFRU hash sums.
+    RHash is a console utility for computing and verifying hash sums of files. 
+    It supports CRC32, MD4, MD5, SHA1, SHA256, SHA512, SHA3, Tiger, TTH, Torrent BTIH, AICH, ED2K, GOST R 34.11-94, RIPEMD-160, HAS-160, EDON-R 256/512, WHIRLPOOL and SNEFRU hash sums.
   doc_url: https://rhash.sourceforge.net/manpage.php
   dev_url: https://github.com/rhash/RHash
 
@@ -55,3 +57,5 @@ extra:
   recipe-maintainers:
     - xantares
     - isuruf
+  skip-lints:
+    - should_use_stdlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - make                 # [unix]
   host:
@@ -57,5 +58,3 @@ extra:
   recipe-maintainers:
     - xantares
     - isuruf
-  skip-lints:
-    - should_use_stdlib


### PR DESCRIPTION
rhash 1.4.6 

**Destination channel:** Defaults

### Links

- [PKG-9904]
- dev_url:        https://github.com/rhash/RHash/tree/v1.4.6
- conda_forge:    https://github.com/conda-forge/rhash-feedstock
- pypi:           https://www.google.com/
- pypi inspector: https://www.google.com/

### Explanation of changes:

- new version number


[PKG-9904]: https://anaconda.atlassian.net/browse/PKG-9904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ